### PR TITLE
quick supression of oplocks flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+#2017-05-03 - Release 0.4.2
+
+needing this one again... fixed some bad client settings stuff for oplocks which doesnt seem to exist in 2016 at the very least... 
+
 #2016-04-26 - Release 0.4.1
 
 ##NOTE NEW DEPENDENCY ON `puppetlabs_registry` as of 0.4.0 - see metadata.json

--- a/manifests/manage_smb_client_config.pp
+++ b/manifests/manage_smb_client_config.pp
@@ -175,10 +175,10 @@ define windows_smb::manage_smb_client_config (
         data => $smb_client_keep_connection_seconds,
       }
       ,
-      'HKLM\SYSTEM\CurrentControlSet\Services\SmbMRx\Parameters\OplocksDisabled'                                   => {
-        data => $smb_client_oplocks_reg_dword,
-      }
-      ,
+      #'HKLM\SYSTEM\CurrentControlSet\Services\SmbMRx\Parameters\OplocksDisabled'                                   => {
+      #  data => $smb_client_oplocks_reg_dword,
+      #}
+      #,
       'HKLM\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\SESSTIMEOUT'                            => {
         data => $smb_client_session_timeout_seconds,
       }
@@ -277,10 +277,10 @@ define windows_smb::manage_smb_client_config (
         data => 600,
       }
       ,
-      'HKLM\SYSTEM\CurrentControlSet\Services\SmbMRx\Parameters\OplocksDisabled'                                   => {
-        data => 0,
-      }
-      ,
+      #'HKLM\SYSTEM\CurrentControlSet\Services\SmbMRx\Parameters\OplocksDisabled'                                   => {
+      #  data => 0,
+      #}
+      #,
       'HKLM\System\CurrentControlSet\Services\LanmanWorkstation\Parameters\SESSTIMEOUT'                            => {
         data => 60,
       }

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
 	"name": "karmafeast-windows_smb",
-	"version": "0.4.1",
+	"version": "0.4.2",
 	"author": "karmafeast",
 	"summary": "Module that will manage windows SMB shares, server and client SMB configuration",
 	"license": "Apache-2.0",
@@ -9,10 +9,10 @@
 	"issues_url": "https://github.com/karmafeast/windows_smb/issues",
 	"dependencies": [{
 			"name": "puppetlabs/stdlib",
-			"version_requirement": ">= 4.6.0 < 5.0.0"
+			"version_requirement": ">= 4.6.0 < 10.0.0"
 		},{
 			"name": "puppetlabs/powershell",
-			"version_requirement": ">= 1.0.1 < 2.0.0"
+			"version_requirement": ">= 1.0.1 < 10.0.0"
 		},{
 			"name": "puppet/windowsfeature",
 			"version_requirement": ">= 1.1.0 < 10.0.0"
@@ -30,6 +30,7 @@
 			"operatingsystemrelease": [ "2008R2",
 				"2012",
 				"2012R2",
+				"2016",
 				"10.x"
 			]
 		}


### PR DESCRIPTION
the parent key isn't there anymore in 2016.  this can easily be improved by os filtering the processing of each element.  I'd have done that but am unsure if this setting exists in 2012r2.  I'd swear it does... dont have a machine on hand... anyhoo...